### PR TITLE
Add support for locating jag::Isaac::Init & jag::Isaac::Generate

### DIFF
--- a/ClientTcpMessage.py
+++ b/ClientTcpMessage.py
@@ -89,7 +89,7 @@ class ClientTcpMessage:
                  .format(fn_make_client_message.start))
 
         self.found_data.make_client_message_addr = fn_make_client_message.start
-        rename_func(fn_make_client_message, "jag::game::ServerConnection::MakeClientMessage<jag::ClientProt>")
+        change_func_name(fn_make_client_message, "jag::game::ServerConnection::MakeClientMessage<jag::ClientProt>")
 
         self._addr_some_clientprot = self._find_clientprot_addr(func_calling_make_client_message,
                                                           insn_call_make_client_message)
@@ -118,7 +118,7 @@ class ClientTcpMessage:
                 num_register_refs = len(list(bv.get_code_refs(ptr.constant)))
                 if self.MIN_CLIENT_PROTS < num_register_refs < self.MAX_CLIENT_PROTS:
                     func = bv.get_function_at(ptr.constant)
-                    rename_func(func, 'jag::RegisterClientProt')
+                    change_func_name(func, 'jag::RegisterClientProt')
                     if len(func.parameter_vars) == 3:
                         change_var(func.parameter_vars[0], 'pClientProt', Type.pointer(bv.arch, self.found_data.types.client_prot))
                         change_var(func.parameter_vars[1], 'opCode', Type.int(4, False))

--- a/Isaac.py
+++ b/Isaac.py
@@ -1,0 +1,65 @@
+"""
+Copyright 2022 AridTag
+This file is part of BinjaNxt.
+BinjaNxt is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+BinjaNxt is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with BinjaNxt.
+If not, see <https://www.gnu.org/licenses/>.
+"""
+from BinjaNxt.JagTypes import *
+from BinjaNxt.NxtAnalysisData import NxtAnalysisData
+from BinjaNxt.NxtUtils import *
+from BinjaNxt.PacketHandlerInfo import *
+from binaryninja import *
+
+
+class Isaac:
+    found_data: NxtAnalysisData
+
+    def __init__(self, found_data: NxtAnalysisData):
+        self.found_data = found_data
+
+    def run(self, bv: BinaryView) -> bool:
+        isaac_init_addr = None
+        max_isaac_constants = 0
+        for func in bv.functions:
+            if not ensure_func_analyzed(func):
+                continue
+            isaac_cipher_key = 0
+            isaac_constants_found = 0
+            for insn in func.llil.instructions:
+                isaac_cipher_key += insn.prefix_operands.count(0x9e3779b9)
+                quantity_of_constant = insn.prefix_operands.count(0x404)
+                isaac_constants_found += quantity_of_constant
+            if isaac_constants_found >= 1 and isaac_cipher_key == 1:
+                log_info(
+                    "0x404 located {} times in function starting at {}".format(isaac_constants_found, hex(func.start)))
+                if isaac_constants_found > max_isaac_constants:
+                    max_isaac_constants = isaac_constants_found
+                    isaac_init_addr = func.start
+        if isaac_init_addr is None:
+            return False
+        self.found_data.isaac_init_addr = isaac_init_addr
+        log_info('Found jag::Isaac::Init @ ' + hex(self.found_data.isaac_init_addr))
+        change_func_name(bv.get_function_at(self.found_data.isaac_init_addr), 'jag::Isaac::Init')
+        isaac_generate_addr = None
+        for insn in bv.get_function_at(isaac_init_addr).llil.instructions:
+            if not isinstance(insn, LowLevelILCall):
+                continue
+            call_insn: LowLevelILCall = insn
+            called = get_called_func(bv, call_insn)
+            if called is None:
+                continue
+            isaac_generate_addr = called.start
+            break
+        if isaac_generate_addr is None:
+            return False
+        self.found_data.isaac_generate_addr = isaac_generate_addr
+        log_info('Found jag::Isaac::Generate @ ' + hex(self.found_data.isaac_generate_addr))
+        change_func_name(bv.get_function_at(self.found_data.isaac_generate_addr), 'jag::Isaac::Generate')
+        return True

--- a/JagTypes.py
+++ b/JagTypes.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 from binaryninja import Type, BinaryView
 
 
@@ -31,9 +32,10 @@ class JagTypes:
 
     def create_types(self, bv: BinaryView):
         t_isaac = Type.structure(members=[
-            (Type.int(4, False), 'valuesRemaining'),
-            (Type.array(Type.int(4, False), 256), 'rand_results'),
+            (Type.int(4, False), 'valuesRemaining'),  # This may actually be value used, investigate.
+            (Type.array(Type.int(4, False), 256), 'results'),
             (Type.array(Type.int(4, False), 256), 'mm'),
+            # One of these is the counter, another is the accumulator
             (Type.int(4), 'aa'),
             (Type.int(4), 'bb'),
             (Type.int(4), 'cc')

--- a/Nxt.py
+++ b/Nxt.py
@@ -62,7 +62,7 @@ class Nxt:
         if main_init is None:
             return False
 
-        rename_func(main_init, 'jag::App::MainInit')
+        change_func_name(main_init, 'jag::App::MainInit')
 
         if not self.find_alloc_and_client_ctor(bv, main_init):
             return False
@@ -152,7 +152,7 @@ class Nxt:
                 found_alloc = True
                 checked_alloc = bv.get_function_at(dest_addr)
                 self.found_data.checked_alloc_addr = checked_alloc.start
-                rename_func(checked_alloc, '{}::CheckedAlloc'.format(self.found_data.types.heap_interface_name))
+                change_func_name(checked_alloc, '{}::CheckedAlloc'.format(self.found_data.types.heap_interface_name))
                 change_ret_type(checked_alloc, Type.pointer(bv.arch, Type.void()))
                 change_var(checked_alloc.parameter_vars[0], 'num_bytes', Type.int(4))
                 change_var(checked_alloc.parameter_vars[1], 'alignment', Type.int(4))
@@ -167,7 +167,7 @@ class Nxt:
 
                 client_ctor = bv.get_function_at(dest_addr)
                 self.found_data.client_ctor_addr = client_ctor.start
-                rename_func(client_ctor, '{}::ctor'.format(self.found_data.types.client_name))
+                change_func_name(client_ctor, '{}::ctor'.format(self.found_data.types.client_name))
                 change_var(client_ctor.parameter_vars[0], 'pClient',
                            Type.pointer(bv.arch, self.found_data.types.client))
                 break
@@ -388,9 +388,9 @@ class Nxt:
         self.found_data.connection_manager_ctor_addr = ctor.start
         log_info('Found jag::ConnectionManager::ctor at {:#x}'.format(self.found_data.connection_manager_ctor_addr))
 
-        rename_func(ctor, '{}::ctor'.format(self.found_data.types.conn_mgr_name))
+        change_func_name(ctor, '{}::ctor'.format(self.found_data.types.conn_mgr_name))
         change_var_type(ctor.parameter_vars[0], Type.pointer(bv.arch, self.found_data.types.conn_mgr))
-        change_var_type(ctor.parameter_vars[1], Type.pointer(bv.arch, self.found_data.types.client))
+        change_var(ctor.parameter_vars[1], "client", Type.pointer(bv.arch, self.found_data.types.client))
         return True
 
     def find_current_time_addr(self,

--- a/NxtAnalysisData.py
+++ b/NxtAnalysisData.py
@@ -18,6 +18,8 @@ class NxtAnalysisData:
     packet_handlers: list[PacketHandlerInfo] = []
     make_client_message_addr: Optional[int] = None
     register_clientprot_addr: Optional[int] = None
+    isaac_init_addr: Optional[int] = None
+    isaac_generate_addr: Optional[int] = None
     clientprots: list[ClientProtInfo] = []
 
     def print_info(self):

--- a/NxtUtils.py
+++ b/NxtUtils.py
@@ -34,22 +34,21 @@ class AllocationDetails:
 
 
 def int32(x: int):
-  if x>0xFFFFFFFF:
-    raise OverflowError
-  if x>0x7FFFFFFF:
-    x=int(0x100000000-x)
-    if x<2147483648:
-      return -x
-    else:
-      return -2147483648
-  return x
+    if x > 0xFFFFFFFF:
+        raise OverflowError
+    if x > 0x7FFFFFFF:
+        x = int(0x100000000 - x)
+        if x < 2147483648:
+            return -x
+        else:
+            return -2147483648
+    return x
 
 
 def ensure_func_analyzed(func: Function) -> bool:
     if func.analysis_skipped:
         log_warn('Function {} was not analyzed. Reason {}'.format(func.name, func.analysis_skip_reason))
         return False
-
     return True
 
 
@@ -100,12 +99,17 @@ def change_var(var: Variable, name: str, var_type: Type):
         var.set_name_async(name)
 
 
+def change_var_name(var: Variable, name: str):
+    if var.name != name:
+        var.set_name_async(name)
+
+
 def change_var_type(var: Variable, var_type: Type):
     if var.type != var_type:
         var.set_type_async(var_type)
 
 
-def rename_func(func: Function, name: str):
+def change_func_name(func: Function, name: str):
     if func.name != name:
         func.name = name
 

--- a/PacketHandler.py
+++ b/PacketHandler.py
@@ -18,6 +18,9 @@ from BinjaNxt.PacketHandlerInfo import *
 from BinjaNxt.JagTypes import *
 from BinjaNxt.NxtAnalysisData import NxtAnalysisData
 
+from BinjaNxt.NxtUtils import *
+from BinjaNxt.PacketHandlerInfo import PacketHandlerInfo, server_packet_names
+
 
 #from NxtAnalysisData import NxtAnalysisData
 #from JagTypes import *
@@ -42,10 +45,10 @@ class PacketHandlers:
             return False
 
         log_info('Found RegisterPacketHandler @ ' + hex(self.found_data.register_packet_handler_addr))
-        rename_func(bv.get_function_at(self.found_data.register_packet_handler_addr), 'jag::RegisterPacketHandler')
+        change_func_name(bv.get_function_at(self.found_data.register_packet_handler_addr), 'jag::RegisterPacketHandler')
 
         log_info('Found jag::PacketHandler::ctor @ ' + packet_handler_ctor.name)
-        rename_func(packet_handler_ctor, 'jag::PacketHandler::ctor')
+        change_func_name(packet_handler_ctor, 'jag::PacketHandler::ctor')
 
         if not self.__initialize_server_packet_infos(bv, packet_handler_ctor):
             log_error('Failed to initialize PacketHandler info')
@@ -61,7 +64,7 @@ class PacketHandlers:
 
             qualified_handler_name, clean_name = self.get_qualified_handler_name(handler.name)
             handler_ctor = bv.get_function_at(handler.ctor)
-            rename_func(handler_ctor, '{}::ctor'.format(qualified_handler_name))
+            change_func_name(handler_ctor, '{}::ctor'.format(qualified_handler_name))
 
             bv.define_data_var(handler.addr - 0x8,
                                self.found_data.types.server_prot,
@@ -91,7 +94,7 @@ class PacketHandlers:
                         # TODO: Can I create a function? what is a "user" function?
                         print('no func?')
                     else:
-                        rename_func(handle_packet_func, '{}::HandlePacket'.format(qualified_handler_name))
+                        change_func_name(handle_packet_func, '{}::HandlePacket'.format(qualified_handler_name))
 
                         if len(handle_packet_func.parameter_vars) >= 2:
                             change_var(handle_packet_func.parameter_vars[1], 'pPacket', Type.pointer(bv.arch, self.found_data.types.packet))


### PR DESCRIPTION
I've added support for locating and renaming the jag::Isaac::Init and jag::Isaac::Generate functions which are in the Isaac cipher implementation. 